### PR TITLE
Add control for fonts

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,5 +15,88 @@
 - Header https://v2.rivet.iu.edu/docs/components/header/
 - Footer https://v2.rivet.iu.edu/docs/components/footer/
 
+#### Fonts
+- CSS is set up to "inherit" a site's default font. 
+- To "inherit" IU fonts for a component add the following code to the top of the component CSS
+```
+@font-face {
+  font-family: BentonSans;
+  font-style: normal;
+  font-weight: 400;
+  src: url(https://fonts.iu.edu/fonts/benton-sans-regular.eot);
+  src: url(https://fonts.iu.edu/fonts/benton-sans-regular.eot#iefix)
+      format("embedded-opentype"),
+    url(https://fonts.iu.edu/fonts/benton-sans-regular.woff) format("woff"),
+    url(https://fonts.iu.edu/fonts/benton-sans-regular.ttf) format("truetype"),
+    url(https://fonts.iu.edu/fonts/benton-sans-regular.svg#BentonSansRegular)
+      format("svg");
+  font-display: swap;
+}
+@font-face {
+  font-family: BentonSans;
+  font-style: normal;
+  font-weight: 500;
+  src: url(https://fonts.iu.edu/fonts/benton-sans-medium.eot);
+  src: url(https://fonts.iu.edu/fonts/benton-sans-medium.eot#iefix)
+      format("embedded-opentype"),
+    url(https://fonts.iu.edu/fonts/benton-sans-medium.woff) format("woff"),
+    url(https://fonts.iu.edu/fonts/benton-sans-medium.ttf) format("truetype"),
+    url(https://fonts.iu.edu/fonts/benton-sans-medium.svg#BentonSansMedium)
+      format("svg");
+  font-display: swap;
+}
+@font-face {
+  font-family: BentonSans;
+  font-style: normal;
+  font-weight: 700;
+  src: url(https://fonts.iu.edu/fonts/benton-sans-bold.eot);
+  src: url(https://fonts.iu.edu/fonts/benton-sans-bold.eot#iefix)
+      format("embedded-opentype"),
+    url(https://fonts.iu.edu/fonts/benton-sans-bold.woff) format("woff"),
+    url(https://fonts.iu.edu/fonts/benton-sans-bold.ttf) format("truetype"),
+    url(https://fonts.iu.edu/fonts/benton-sans-bold.svg#BentonSansRegular)
+      format("svg");
+  font-display: swap;
+}
+@font-face {
+  font-family: GeorgiaPro;
+  font-style: normal;
+  font-weight: 400;
+  src: url(https://fonts.iu.edu/fonts/georgia-pro-regular.eot);
+  src: url(https://fonts.iu.edu/fonts/georgia-pro-regular.eot#iefix)
+      format("embedded-opentype"),
+    url(https://fonts.iu.edu/fonts/georgia-pro-regular.woff) format("woff"),
+    url(https://fonts.iu.edu/fonts/georgia-pro-regular.ttf) format("truetype"),
+    url(https://fonts.iu.edu/fonts/georgia-pro-regular.svg#GeorgiaProRegular)
+      format("svg");
+  font-display: swap;
+}
+@font-face {
+  font-family: GeorgiaPro;
+  font-style: italic;
+  font-weight: 400;
+  src: url(https://fonts.iu.edu/fonts/georgia-pro-italic.eot);
+  src: url(https://fonts.iu.edu/fonts/georgia-pro-italic.eot#iefix)
+      format("embedded-opentype"),
+    url(https://fonts.iu.edu/fonts/georgia-pro-italic.woff) format("woff"),
+    url(https://fonts.iu.edu/fonts/georgia-pro-italic.ttf) format("truetype"),
+    url(https://fonts.iu.edu/fonts/georgia-pro-italic.svg#GeorgiaProItalic)
+      format("svg");
+  font-display: swap;
+}
+@font-face {
+  font-family: GeorgiaPro;
+  font-style: normal;
+  font-weight: 700;
+  src: url(https://fonts.iu.edu/fonts/georgia-pro-bold.eot);
+  src: url(https://fonts.iu.edu/fonts/georgia-pro-bold.eot#iefix)
+      format("embedded-opentype"),
+    url(https://fonts.iu.edu/fonts/georgia-pro-bold.woff) format("woff"),
+    url(https://fonts.iu.edu/fonts/georgia-pro-bold.ttf) format("truetype"),
+    url(https://fonts.iu.edu/fonts/georgia-pro-bold.svg#GeorgiaProBold)
+      format("svg");
+  font-display: swap;
+}
+```
 #### Source
 - "src" is a clone of source files from the active Rivet repository https://github.com/indiana-university/rivet-source/ 

--- a/dist/footer/css/rvt-footer.css
+++ b/dist/footer/css/rvt-footer.css
@@ -23,9 +23,11 @@
     background-color: #006298
 }
 
+/* add font inherit */
 .rvt-footer-base {
+    font: inherit;
     background-color: #900;
-    color: #fff
+    color: #fff;
 }
 
 .rvt-footer-base__inner {

--- a/dist/header/css/rvt-header.css
+++ b/dist/header/css/rvt-header.css
@@ -354,7 +354,10 @@
     border-radius: 0;
     margin-left: -2px
 }
+
+/* add font:inherit for integrating IU font */
 .rvt-header-global {
+    font: inherit;
     padding-top: 1rem;
     padding-bottom: 1rem;
     position: relative;


### PR DESCRIPTION
Adds a font:inherit directive to a top-level class of each component. IU-specific fonts for components can be ingested by pasting in fonts code found in README.md.  